### PR TITLE
ปรับตำแหน่ง dictionary ใน ex1

### DIFF
--- a/project_rust/ex1/src/main.rs
+++ b/project_rust/ex1/src/main.rs
@@ -46,12 +46,13 @@ fn main() -> Result<()> { // Note, this is anyhow::Result
     // Open the web-camera (assuming you have one)
     let mut cam = videoio::VideoCapture::new(0, videoio::CAP_ANY)?;
     
+    let dictionary_ptr = aruco::get_predefined_dictionary(aruco::PREDEFINED_DICTIONARY_NAME::DICT_6X6_250)?;
+
     loop {
         let start = Instant::now();
         let mut frame = Mat::default();
-        let dictionary_ptr = aruco::get_predefined_dictionary(aruco::PREDEFINED_DICTIONARY_NAME::DICT_6X6_250)?;
         cam.read(&mut frame)?;
-        find_aruco_markers(&mut frame,dictionary_ptr);
+        find_aruco_markers(&mut frame, dictionary_ptr.clone());
         highgui::imshow("window", &frame)?;
         let key = highgui::wait_key(1)?;
         if key == 113 { // quit with q


### PR DESCRIPTION
## Summary
- ย้ายการสร้าง `dictionary_ptr` ออกมานอกลูปเพื่อใช้ซ้ำ
- ส่ง pointer เดิมเข้า `find_aruco_markers` ทุกครั้ง

## Testing
- `cargo check --manifest-path project_rust/ex1/Cargo.toml` *(fail: network error)*

------
https://chatgpt.com/codex/tasks/task_e_687c5b47cbfc832b9b28b995416532e7